### PR TITLE
fix: add timeout to network request

### DIFF
--- a/offchain-modules/lib/src/lib.rs
+++ b/offchain-modules/lib/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(async_closure)]
 pub mod relay;
 pub mod server;
 pub mod transfer;

--- a/offchain-modules/lib/src/server/handlers.rs
+++ b/offchain-modules/lib/src/server/handlers.rs
@@ -72,6 +72,19 @@ pub async fn get_eth_to_ckb_status(
     Ok(HttpResponse::Ok().json(status))
 }
 
+#[post("/get_ckb_to_eth_status")]
+pub async fn get_ckb_to_eth_status(
+    data: web::Data<DappState>,
+    args: web::Json<Value>,
+) -> actix_web::Result<HttpResponse, RpcError> {
+    let args: CkbBurnTxHash =
+        serde_json::from_value(args.into_inner()).map_err(|e| format!("invalid args: {}", e))?;
+    let status = db::get_ckb_to_eth_status(&data.db, &args.ckb_burn_tx_hash)
+        .await?
+        .ok_or(format!("ckb burn tx {} not found", &args.ckb_burn_tx_hash))?;
+    Ok(HttpResponse::Ok().json(status))
+}
+
 #[post("/get_crosschain_history")]
 pub async fn get_crosschain_history(
     data: web::Data<DappState>,

--- a/offchain-modules/lib/src/server/handlers.rs
+++ b/offchain-modules/lib/src/server/handlers.rs
@@ -139,7 +139,7 @@ pub async fn relay_eth_to_ckb_proof(
                 eth_lock_tx_hash,
                 e
             )
-                .into());
+            .into());
         };
     }
     let row_id = create_db_res.unwrap();

--- a/offchain-modules/lib/src/server/handlers.rs
+++ b/offchain-modules/lib/src/server/handlers.rs
@@ -125,7 +125,9 @@ pub async fn relay_eth_to_ckb_proof(
         db::create_eth_to_ckb_status_record(&data.db, eth_lock_tx_hash.clone()).await;
     if let Err(e) = &create_db_res {
         if e.to_string().contains("UNIQUE constraint failed") {
-            let record = db::get_eth_to_ckb_status(&data.db, eth_lock_tx_hash.as_str()).await?.expect("EthToCkbRecord existed");
+            let record = db::get_eth_to_ckb_status(&data.db, eth_lock_tx_hash.as_str())
+                .await?
+                .expect("EthToCkbRecord existed");
             if record.status != "timeout" || !data.add_relaying_tx(eth_lock_tx_hash.clone()).await {
                 return Ok(HttpResponse::Ok().json(json!({
                     "message": "tx proof relay processing/processed"

--- a/offchain-modules/lib/src/server/proof_relayer/db.rs
+++ b/offchain-modules/lib/src/server/proof_relayer/db.rs
@@ -37,7 +37,7 @@ pub async fn update_eth_to_ckb_status(pool: &SqlitePool, record: &EthToCkbRecord
     log::info!("update_eth_to_ckb_status, record: {:?}", record);
     let rows_affected = sqlx::query(
         r#"
-UPDATE eth_to_ckb SET 
+UPDATE eth_to_ckb SET
     status = ?2,
     token_addr = ?3,
     sender_addr = ?4,
@@ -157,7 +157,7 @@ pub async fn update_ckb_to_eth_status(pool: &SqlitePool, record: &CkbToEthRecord
     log::info!("update_ckb_to_eth_status, record: {:?}", record);
     let rows_affected = sqlx::query(
         r#"
-UPDATE ckb_to_eth SET 
+UPDATE ckb_to_eth SET
     status = ?2,
     recipient_addr = ?3,
     token_addr = ?4,
@@ -185,8 +185,8 @@ WHERE id = ?1
 pub async fn get_ckb_to_eth_status(
     pool: &SqlitePool,
     ckb_burn_tx_hash: &str,
-) -> Result<Option<EthToCkbRecord>> {
-    Ok(sqlx::query_as::<_, EthToCkbRecord>(
+) -> Result<Option<CkbToEthRecord>> {
+    Ok(sqlx::query_as::<_, CkbToEthRecord>(
         r#"
 SELECT *
 FROM ckb_to_eth

--- a/offchain-modules/lib/src/server/proof_relayer/handler.rs
+++ b/offchain-modules/lib/src/server/proof_relayer/handler.rs
@@ -30,11 +30,24 @@ pub async fn relay_ckb_to_eth_proof(
         .deployed_contracts
         .as_ref()
         .ok_or_else(|| anyhow!("contracts should be deployed"))?;
-    let (tx_proof, tx_info) = get_ckb_proof_info(&ckb_tx_hash, ckb_rpc_url.clone())?;
+    let try_get_ckb_proof = async || {
+        let mut error = "".to_string();
+        for _ in 0..3 {
+            let ret = get_ckb_proof_info(&ckb_tx_hash, ckb_rpc_url.clone());
+            if ret.is_ok() {
+                return ret;
+            }
+            error = format!("{}", ret.unwrap_err());
+            tokio::time::delay_for(std::time::Duration::from_secs(60)).await;
+        }
+        bail!("get ckb burn tx proof failed: {}", error);
+    };
+    let (tx_proof, tx_info) = try_get_ckb_proof().await?;
+
     let light_client = convert_eth_address(&deployed_contracts.eth_ckb_chain_addr)?;
     let lock_contract_addr = convert_eth_address(&deployed_contracts.eth_token_locker_addr)?;
 
-    let timeout_future = tokio::time::delay_for(std::time::Duration::from_secs(1800));
+    let timeout_future = tokio::time::delay_for(std::time::Duration::from_secs(3600));
     let wait_header_future = wait_block_submit(
         ethereum_rpc_url.clone(),
         ckb_rpc_url,

--- a/offchain-modules/lib/src/server/proof_relayer/handler.rs
+++ b/offchain-modules/lib/src/server/proof_relayer/handler.rs
@@ -109,7 +109,7 @@ pub async fn relay_eth_to_ckb_proof(
         ethereum_rpc_url.clone(),
         eth_token_locker_addr.clone(),
     )
-        .await?;
+    .await?;
     let force_config = ForceConfig::new(config_path.as_str())?;
     let deployed_contracts = force_config
         .deployed_contracts
@@ -139,7 +139,7 @@ pub async fn relay_eth_to_ckb_proof(
         &eth_proof,
         from_privkey,
     )
-        .await?;
+    .await?;
     log::info!(
         "relay lock tx {} successfully, mint tx {}",
         eth_lock_tx_hash,

--- a/offchain-modules/lib/src/server/state.rs
+++ b/offchain-modules/lib/src/server/state.rs
@@ -89,7 +89,7 @@ impl DappState {
             self.indexer_url.clone(),
             self.deployed_contracts.clone(),
         )
-            .map_err(|e| anyhow!("new geneartor fail, err: {}", e))?;
+        .map_err(|e| anyhow!("new geneartor fail, err: {}", e))?;
         ensure_indexer_sync(&mut generator.rpc_client, &mut generator.indexer_client, 60)
             .await
             .map_err(|e| anyhow!("failed to ensure indexer sync : {}", e))?;

--- a/offchain-modules/lib/src/server/types.rs
+++ b/offchain-modules/lib/src/server/types.rs
@@ -17,6 +17,11 @@ pub struct EthLockTxHash {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CkbBurnTxHash {
+    pub ckb_burn_tx_hash: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetEthToCkbStatusArgs {
     pub ckb_recipient_lockscript: String,
 }

--- a/offchain-modules/lib/src/transfer/to_ckb.rs
+++ b/offchain-modules/lib/src/transfer/to_ckb.rs
@@ -297,12 +297,15 @@ pub async fn send_eth_spv_proof_tx(
                     retry_times, e
                 );
                 log::info!("{}", error_msg);
+                if error_msg.contains("ValidationFailure(-1)") {
+                    anyhow::bail!(error_msg);
+                }
             }
         }
         tokio::time::delay_for(std::time::Duration::from_secs(retry_times * 3 + 1)).await;
     }
     anyhow::bail!(
-        "lock tx {} related mint tx is not committed, reach max retry times. latest error_msg: {}",
+        "lock tx {} related mint tx is not committed, reach max retry times timeout. latest error_msg: {}",
         eth_lock_tx,
         error_msg
     )


### PR DESCRIPTION
1. add timeout to ckb2eth relay
2. add timeout to tx relay when waiting for header sync
3. optimize relay_eth_to_ckb_proof
- error handle
  - return immediately if script verify error
  - add "timeout" to record status, which is retryable 
- make the api  retryable
4. optimize burn api
5. add get_ckb_to_eth_status api